### PR TITLE
fix(treesitter): update vimdoc from `neovim/tree-sitter-vimdoc`

### DIFF
--- a/after/queries/vimdoc/highlights.scm
+++ b/after/queries/vimdoc/highlights.scm
@@ -1,31 +1,71 @@
 ;; extends
 
+; Taken from https://github.com/neovim/tree-sitter-vimdoc/blob/master/queries/vimdoc/highlights.scm
+
+(h1
+  (delimiter) @markup.heading.1
+  (heading) @markup.heading.1)
+
+(h2
+  (delimiter) @markup.heading.2
+  (heading) @markup.heading.2)
+
+(h3
+  (heading) @markup.heading.3)
+
+(column_heading
+  (heading) @markup.heading.4)
+
+(column_heading
+  (delimiter) @markup.heading.4.marker
+  (#set! conceal ""))
+
 (tag
-  text: (_) @markup.link.label)
+  "*" @markup.heading.5.marker
+  (#set! conceal "")
+  text: (_) @label)
+
+(taglink
+  "|" @markup.link
+  (#set! conceal "")
+  text: (_) @markup.link)
 
 (optionlink
-  text: (_) @property)
+  text: (_) @markup.link)
 
 (codespan
-  "`" @markup.raw.delimiter
-  (#set! conceal ""))
+  "`" @markup.raw
+  (#set! conceal "")
+  text: (_) @markup.raw)
+
+((codeblock) @markup.raw.block
+  (#set! "priority" 90))
 
 (codeblock
-  ">" @markup.raw.delimiter
-  (#set! conceal ""))
-
-(codeblock
-  (language) @markup.raw
+  [
+    ">"
+    (language)
+  ] @markup.raw.block
   (#set! conceal ""))
 
 (block
-  "<" @markup.raw.delimiter
+  "<" @markup.raw.block
   (#set! conceal ""))
 
-(column_heading
-  "~" @markup.raw.delimiter
-  (#set! conceal ""))
+(argument) @variable.parameter
 
-(tag
-  "*" @markup.raw.delimiter
-  (#set! conceal ""))
+(keycode) @string.special
+
+(url) @string.special.url
+
+(modeline) @keyword.directive
+
+((note) @comment.hint
+  (#any-of? @comment.hint "Note:" "NOTE:" "Notes:"))
+
+((note) @comment.warning
+  (#any-of? @comment.warning "Warning:" "WARNING:"))
+
+((note) @comment.error
+  (#any-of? @comment.error "Deprecated:" "DEPRECATED:"))
+


### PR DESCRIPTION
Previous highlight pattern had an invalid pattern:

```
(tag
  "~" @markup.raw.delimiter
  (#set! conceal ""))
```

Rather than fixing only this issue, copy the whole query from [neovim/tree-sitter-vimdoc](https://github.com/neovim/tree-sitter-vimdoc)